### PR TITLE
State intent to solve problem of requiring assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ planned. However, we plan to:
 
 ## Notebook document
 
+## Kernel specification
+
+Implement a way for static resources (js, css, images, etc.) to be fetched based on the kernel for use by frontends (notebook, thebe, etc.).
+
 ## Message specification
 
 ## Community Pipeline


### PR DESCRIPTION
Libraries, and by extension kernels, have static assets that are required in frontends such as the notebook, thebe, hydrogen, and dashboards.

This issue continues to come up over and over without a total solution. At the very least I'd like for us to put it on the roadmap and acknowledge that we will solve it. My text description may not be the best, please let me know how to update/fix it.

Initial (old) proposal/discussion: jupyter/notebook#116
Related: jupyter/notebook#839

As it applies to Thebe, they currently have to bundle
- all notebook js (not tied to kernel)
- ipywidgets js (tied to kernel)
- thebe itself

Each thebe release has to strictly specify the version of notebook, ipywidgets, in addition to thebe itself, and is incompatible with other versions.

Discussion from the Spring Jupyter Dev Meeting 2016: https://jupyter.hackpad.com/Spring-2016-Dev-Meeting-h0y1TIAWxz1#:h=Kernel-Static-Resources

/cc @parente @minrk @jdfreder @ellisonbg 
