### PR TITLE
Add UX survey items to notebook future

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,13 @@ each milestone.
 * Perform and publish accesibility audit by running an automated tool.
 * Bring our core plugins up to the level of the Web Accessibility Standards
   (http://www.w3.org/standards/webdesign/accessibility)
-
+* Address the [2015 UX survey findings](https://github.com/jupyter/design/blob/master/surveys/2015-notebook-ux/analysis/report_dashboard.ipynb)
+    * Version control (via git in particular)
+    * Robust text and code editing (like in Emacs, Vim, Sublime, PyCharm)
+    * Advanced code development tools (debugging, profiling, variable watching, code modularization)
+    * Simpler export and deployment options (one-click transformations to slides, scripts, reports)
+    * Improved installation guides, usage tutorials, and within-tool help
+      
 ## ipywidgets
 
 ### Next (5.0)


### PR DESCRIPTION
We discussed the results of the UX survey. I'm opening this PR to suggest that the roadmap should at least capture the top user requests for consideration in future development plans. I do not know who would do the implementation or how, but it feels disingenuous to leave it out completely.

I put the bullets under Notebook -> Future for now.

Strawman: Could version control, better text editing features (e.g., vi shortcuts), dev tools (e.g., variable watcher) be implemented as Jupyter Lab plugins to start to draw interest toward the new UX?
