### PR TITLE
Add heading stub for Qt Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,3 +434,14 @@ Implement a way for static resources (js, css, images, etc.) to be fetched based
 ## Jupyter Qt Console
 
 - The functionality of the Qt Console is being implemented inside JupyterLab.
+- The goal of the initial version of the JupyterLab console is feature parity
+  with the Qt Console application.
+- The JupyterLab console will also support any cells that a notebook can render.
+
+### Next
+- There is currently no "save session" functionality. There are several ways the
+  mechanics of saving the content of a console session might be implemented. A
+  discussion of its semantics may be fruitful and may lead to an interesting
+  "save" feature for the next version.
+- A full replacement of the Qt Console application may require wrapping the web
+  version in a native application in the next version.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ each milestone.
 	  * These releases will have bug fixes and new features in JupyterLab designed to get JupyterLab to  Phase 2.
 	  * During this phase, we will continue to work on porting nbextensions to JupyterLab and building the bridge layers.
 	  * Explicit that people can request help for porting extensions.
-	  * *Criteria for transition to phase 2:* 
+	  * *Criteria for transition to phase 2:*
 		1. Jupyter Lab has all the primary functionality of the classic notebook interface.
 		1. Jupyter Lab offers some interesting features beyond the classic interface.
 		1. At least some important, popular extensions are ported / bridged to Jupyter Lab.
@@ -111,7 +111,7 @@ each milestone.
 	* Phase 2:
 	  * A series of major releases that will have JupyterLab as the main UI and the old notebook is available as a button
 	  * At this point, we start to discourage the development of new features in the existing notebook.
-	  * *Criteria for transition to phase 3:* 
+	  * *Criteria for transition to phase 3:*
 		1. No major development or use of the classic UI.
 	* Phase 3:
 	  * Starting with the z.0 major release. will remove the existing notebook pages.
@@ -142,7 +142,7 @@ each milestone.
     * Advanced code development tools (debugging, profiling, variable watching, code modularization)
     * Simpler export and deployment options (one-click transformations to slides, scripts, reports)
     * Improved installation guides, usage tutorials, and within-tool help
-      
+
 ## ipywidgets
 
 ### Next (5.0)
@@ -430,3 +430,7 @@ Implement a way for static resources (js, css, images, etc.) to be fetched based
   closed automatically).
 - Create a mentorship mailing list (based on the Python Core Mentorship mailing
   list) for new contributors to ask questions
+
+## Jupyter Qt Console
+
+- The functionality of the Qt Console is being implemented inside JupyterLab.


### PR DESCRIPTION
The roadmap thinking for the new version of the console that will appear in JupyterLab needs to be documented, but others will need to chime in.

This PR is just to raise the subject.
