### PR TITLE
Add JupyterLab link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ some cases, if progress is made more quickly, features may be moved to earlier r
 
 * [IPython](ipython.md)
 * [Jupyter Notebook](notebook.md)
+* [JupyterLab](jupyterlab.md)
 * [JupyterHub](jupyterhub.md)
 * [Documentation](documentation.md)
 * [Deployment](deployment.md)


### PR DESCRIPTION
BTW, is this "roadmap" project still used? It seems a bit outdated ...

I actually wanted to find this information:

Is it already decided whether JupyterLab will replace the Notebook?
If not, when will it be decided?

Will there be a feature freeze (or something similar) of the Notebook in order to concentrate work on JupyterLab?